### PR TITLE
[IGVM] add config file and ec private key as input arguments to igvm script

### DIFF
--- a/scripts/tei_config.json
+++ b/scripts/tei_config.json
@@ -1,0 +1,17 @@
+{
+    "tei_config_name" : "confidential_ml_cvm",
+    "tei_config_version"     : 1,
+    "tei_config_data" : {
+        "version"   : 1,
+        "guest_svn" : 2,
+        "family_id" : "12161A1B12161A1B12161A1B12161A1B",
+        "image_id"  : "1A1B12161A1B12161A1B12161A1B1216",
+        "policy":{
+            "debug_allowed" : false,
+            "migrate_ma"    : false,
+            "smt_allowed"   : true,
+            "abi_major"     : 0,
+            "abi_minor"     : 31
+        }
+    }
+}


### PR DESCRIPTION
Developer can specify isolated guest VM signing time configurations as an an input json file.
For signing SNP_ID_BLOCK, developer need to supply ec key as input to igvmfile.py script.