### PR TITLE
Replace unnecessary and expensive PSP launch_update wth guest pvalidate.

### DIFF
--- a/arch/x86/boot/compressed/head_64.S
+++ b/arch/x86/boot/compressed/head_64.S
@@ -345,6 +345,14 @@ SYM_CODE_START(startup_64)
 	cld
 	cli
 
+#ifdef CONFIG_AMD_MEM_ENCRYPT
+	/* pvalidate memory on demand if SNP is enabled. */
+	pushq	%rsi
+	movq    %rsi, %rdi
+	call 	pvalidate_for_startup_64
+	popq	%rsi
+#endif
+
 	/* Setup data segments. */
 	xorl	%eax, %eax
 	movl	%eax, %ds

--- a/arch/x86/boot/compressed/sev-snp.c
+++ b/arch/x86/boot/compressed/sev-snp.c
@@ -144,34 +144,52 @@ void sev_snp_register_ghcb(unsigned long paddr)
 static void extend_e820_on_demand(struct boot_e820_entry *e820_entry,
 				  u64 needed_ram_end)
 {
+	u64 end, paddr;
 	if (!e820_entry) {
 		return;
 	}
-	unsigned long end = e820_entry->addr + e820_entry->size;
+	end = e820_entry->addr + e820_entry->size;
 	if (needed_ram_end > end && e820_entry->type == E820_TYPE_RAM) {
-		for (u64 paddr = end; paddr < needed_ram_end;
-		     paddr += PAGE_SIZE) {
+		for (paddr = end; paddr < needed_ram_end; paddr += PAGE_SIZE) {
 			sev_snp_issue_pvalidate_page(paddr, true);
 		}
 		e820_entry->size = needed_ram_end - e820_entry->addr;
 	}
 }
 
-asmlinkage __visible void pvalidate_for_startup_64(void *rmode)
+/*
+ * Explictly pvalidate needed pages for decompressing the kernel.
+ * The E820_TYPE_RAM entry includes only validated memory. The kernel
+ * expects that the RAM entry's addr is fixed while the entry size is to be
+ * extended to cover addresses to the start of next entry.
+ * The function increases the RAM entry size to cover all possilble memory
+ * addresses until init_size.
+ * For example,  init_end = 0x4000000,
+ * [RAM: 0x0 - 0x0],                       M[RAM: 0x0 - 0xa0000]
+ * [RSVD: 0xa0000 - 0x10000]                [RSVD: 0xa0000 - 0x10000]
+ * [ACPI: 0x10000 - 0x20000]      ==>       [ACPI: 0x10000 - 0x20000]
+ * [RSVD: 0x800000 - 0x900000]              [RSVD: 0x800000 - 0x900000]
+ * [RAM: 0x1000000 - 0x2000000]            M[RAM: 0x1000000 - 0x2001000]
+ * [RAM: 0x2001000 - 0x2007000]            M[RAM: 0x2001000 - 0x4000000]
+
+ Other RAM memory after init_end is pvalidated by ms_hyperv_init_platform
+ */
+__visible void pvalidate_for_startup_64(struct boot_params *boot_params)
 {
+	struct boot_e820_entry *e820_entry;
+	u64 init_end =
+		boot_params->hdr.pref_address + boot_params->hdr.init_size;
+	u64 needed_end;
+	u8 i, nr_entries = boot_params->e820_entries;
 	if (!sev_snp_enabled()) {
 		return;
 	}
-	struct boot_params *bp = (struct boot_params *)rmode;
-	struct boot_e820_entry *e820_entry;
-	u64 needed_end, init_end = bp->hdr.pref_address + bp->hdr.init_size;
-	u8 nr_entries = bp->e820_entries;
-	for (u8 i = 0; i < nr_entries; ++i) {
-		// Pvalidate memory holes in e820 RAM entries.
-		e820_entry = &bp->e820_table[i];
+	for (i = 0; i < nr_entries; ++i) {
+		/* Pvalidate memory holes in e820 RAM entries. */
+		e820_entry = &boot_params->e820_table[i];
 		needed_end = init_end;
 		if (i < nr_entries - 1) {
-			needed_end = bp->e820_table[i + 1].addr;
+			needed_end = boot_params->e820_table[i + 1].addr;
 			BUG_ON(needed_end <
 			       e820_entry->addr + e820_entry->size);
 		}

--- a/arch/x86/boot/compressed/sev-snp.h
+++ b/arch/x86/boot/compressed/sev-snp.h
@@ -20,6 +20,13 @@ void sev_snp_set_page_shared(unsigned long paddr);
 static inline void sev_snp_set_page_private(unsigned long paddr) { }
 static inline void sev_snp_set_page_shared(unsigned long paddr) { }
 
+/* Transition Guest-Invalid pages to Guest-Valid for kernel booting.
+   The startup_64 code needs extra memory
+    * to use uninitialized symbols (startup_32)
+    * to decompress vmlinux.bin to memory
+   This step is used to avoid unnecessary LAUNCH_UPDATE via PSP command.
+*/
+int pvalidate_for_startup_64(void *rmode);
 #endif /* CONFIG_AMD_MEM_ENCRYPT */
 
 #endif /* __COMPRESSED_SECURE_NESTED_PAGING_H */

--- a/arch/x86/boot/compressed/sev-snp.h
+++ b/arch/x86/boot/compressed/sev-snp.h
@@ -20,13 +20,6 @@ void sev_snp_set_page_shared(unsigned long paddr);
 static inline void sev_snp_set_page_private(unsigned long paddr) { }
 static inline void sev_snp_set_page_shared(unsigned long paddr) { }
 
-/* Transition Guest-Invalid pages to Guest-Valid for kernel booting.
-   The startup_64 code needs extra memory
-    * to use uninitialized symbols (startup_32)
-    * to decompress vmlinux.bin to memory
-   This step is used to avoid unnecessary LAUNCH_UPDATE via PSP command.
-*/
-int pvalidate_for_startup_64(void *rmode);
 #endif /* CONFIG_AMD_MEM_ENCRYPT */
 
 #endif /* __COMPRESSED_SECURE_NESTED_PAGING_H */

--- a/scripts/igvmfile.py
+++ b/scripts/igvmfile.py
@@ -1647,8 +1647,8 @@ class IGVMFile(VMState):
 0: memory required used before long mode
 
 HV should launch_update some empty pages since
-    * startup_32 uses boot_stack(unrelocated) and pgtable(relocated)
-    * pvalidate must run after jumping to long mode (startup_64)
+1. startup_32 uses boot_stack(unrelocated) and pgtable(relocated)
+2. pvalidate must run after jumping to long mode (startup_64)
 See more details in arch/x86/boot/compressed/head_64.S
   |<-----------vmlinux.bin-------->|
 A:|*********|*******|**************|------|0000|-------|--------------|

--- a/scripts/igvmfile.py
+++ b/scripts/igvmfile.py
@@ -265,6 +265,8 @@ class setup_header(Structure):
 
 assert sizeof(setup_header) == 0x77
 
+ACPI_END_ADDR = 0x200000
+
 E820_TYPE_RAM           = 1
 E820_TYPE_RESERVED      = 2
 E820_TYPE_ACPI          = 3
@@ -1223,6 +1225,19 @@ class VMState(object):
             self.regs.efer.LMA = 1
             self.regs.efer.NXE = 1
 
+    def setup_acpi(self):
+        # [0-0xa0000] is reserved for BIOS
+        # [0xe0000 - 0x200000] is for ACPI related data
+        # load ACPI pages
+        acpi = pickle.loads(zlib.decompress(base64.b64decode(ACPI)))
+        sorted_gpa = list(acpi.keys())
+        sorted_gpa.sort()
+        for gpa in sorted_gpa:
+            assert(gpa < ACPI_END_ADDR)
+            self.seek(gpa)
+            self.memory.allocate(PGSIZE)
+            self.memory.write(gpa, acpi[gpa]) 
+
     def setup_real(self):
         '''
         Setup registers for real-mode execution.
@@ -1623,35 +1638,91 @@ class IGVMFile(VMState):
         headers[0].TotalFileSize = offset
         return b''.join([bytearray(h) for h in headers]) + body
 
+""" Memory Layout
+|------|-------|**----|*---|***---|*******0-------0|****----|
+  BIOS  RESVD  ACPI   VMSA  cpuids   vmlinux      boot_params
+                            secrets               command
+                            params                ramdisk
+*: data imported and measured 
+0: memory required used before long mode
+
+HV should launch_update some empty pages since
+    * startup_32 uses boot_stack(unrelocated) and pgtable(relocated)
+    * pvalidate must run after jumping to long mode (startup_64)
+See more details in arch/x86/boot/compressed/head_64.S
+  |<-----------vmlinux.bin-------->|
+A:|*********|*******|**************|------|0000|-------|--------------|
+ start_32  start_64  compressed   heap  stack pgtable _end
+  |<-------------------------------init_size ------------------------>|
+
+B:|-------------|---------------------------------------------|0000000|
+                |<-----------vmlinux.bin-------->|          pgtable  _end
+
+startup_32 accesses boot_stack based on the original layout A;
+startup_32 sets up pgtable using future layout B.
+"""
+BOOT_HEAP_SIZE = 0x10000 
+BOOT_STACK_SIZE = 0x4000
+BOOT_PGT_SIZE = 0x6000
+TOP_PGT_SIZE = 0x1000
+INIT_PGTABLE_SIZE = TOP_PGT_SIZE + BOOT_PGT_SIZE
+
 def load_kernel(kernel, cmdline, ramdisk, vtl, config, sign_key):
     assert type(kernel) is bytearray
     assert type(cmdline) is bytearray
     assert type(ramdisk) is bytearray
     state = IGVMFile(config, sign_key)
-    state.memory.allocate(0x200000) # [0-2MB) for ACPI-related data
-    state.memory.allocate(PGSIZE) # VMSA page
+    state.setup_acpi()
+    # VMSA page at 0x200000
+    state.seek(ACPI_END_ADDR)
+    vmsa_page = state.memory.allocate(PGSIZE) # VMSA page
+    
+    # for CPUID/secrets/param pages
     state.seek(0x800000)
-    state.memory.allocate(3 * PGSIZE) # for CPUID/secrets/param pages
+    cpuid_page = state.memory.allocate(PGSIZE) 
+    secrets_page = state.memory.allocate(PGSIZE)
+    param_page = state.memory.allocate(PGSIZE)
+    # Parse BzImage header
     header = setup_header.from_buffer(kernel, 0x1f1)
     assert header.header.to_bytes(4, 'little') == b'HdrS', 'invalid setup_header'
     assert header.pref_address > 3 * 1024 * 1024, 'loading base cannot be below 3MB'
     assert header.xloadflags & 1, '64-bit entrypoint does not exist'
     assert header.pref_address % PGSIZE == 0
     assert header.init_size % PGSIZE == 0
-    kernel_start = (header.setup_sects + 1) * 512
-    assert kernel_start < len(kernel)
-    state.seek(header.pref_address)
-    kernel_base = state.memory.allocate(header.init_size)
-    state.memory.write(kernel_base, kernel[kernel_start:kernel_start + header.init_size])
-    kernel_entry = kernel_base
+    # Skip setup code in real mode
+    vmlinux_bin_start = (header.setup_sects + 1) * 512
+    assert vmlinux_bin_start < len(kernel)
+    # compressed/vmlinux at header.pref_address 
+    kernel_base = header.pref_address
+    kernel_size = header.syssize * 0x10;
+    kernel_size = int((kernel_size + PGSIZE -1) / PGSIZE) * PGSIZE
+    state.seek(kernel_base)
+    kernel_base = state.memory.allocate(kernel_size)
+    vmlinux_bin = kernel[vmlinux_bin_start:]
+    state.memory.write(kernel_base, vmlinux_bin)
+    kernel_end = state.memory.allocate(0)
+
+    # Allocate BOOT_STACK
+    boot_stack_addr = kernel_end + BOOT_HEAP_SIZE
+    state.seek(boot_stack_addr)
+    state.memory.allocate(BOOT_STACK_SIZE)
+
+    # Allocate pgtable
+    pgtable_addr = kernel_base + header.init_size - INIT_PGTABLE_SIZE
+    state.seek(pgtable_addr)
+    state.memory.allocate(INIT_PGTABLE_SIZE)
+    init_end = header.pref_address + header.init_size
+    state.seek(init_end)
+
     # setup architectural env (no paging is needed for 32-bit)
     state.setup_gdt()
     # allocate boot_params, cmdline and ramdisk pages
-    params_page = state.memory.allocate(PGSIZE, PGSIZE)
-    cmdline_page = state.memory.allocate(PGSIZE, PGSIZE)
+    params_page = state.memory.allocate(sizeof(boot_params), 8)
+    cmdline_page = state.memory.allocate(len(cmdline), 8)
     ramdisk_pages = state.memory.allocate(len(ramdisk), PGSIZE)
     end = state.memory.allocate(0, PGSIZE)
     # initialize boot_params
+    kernel_entry = kernel_base
     params = boot_params.from_buffer(state.memory, params_page)
     params.hdr = header
     params.hdr.code32_start = kernel_base
@@ -1664,31 +1735,36 @@ def load_kernel(kernel, cmdline, ramdisk, vtl, config, sign_key):
     params.hdr.ramdisk_size = len(ramdisk)
     params.acpi_rsdp_addr = 0xe0000
     # give 1GB to the kernel
-    params.e820_entries = 5
+    params.e820_entries = 8
     params.e820_table[0].addr = 0
-    params.e820_table[0].size = 0xa0000
+    params.e820_table[0].size = 0
     params.e820_table[0].type = E820_TYPE_RAM
     params.e820_table[1].addr = 0xa0000
     params.e820_table[1].size = 0x100000 - 0xa0000
     params.e820_table[1].type = E820_TYPE_RESERVED
     params.e820_table[2].addr = 0x100000
-    params.e820_table[2].size = 0x100000
+    params.e820_table[2].size = ACPI_END_ADDR - 0x100000
     params.e820_table[2].type = E820_TYPE_ACPI
-    params.e820_table[3].addr = 0x200000
+    params.e820_table[3].addr = ACPI_END_ADDR
     params.e820_table[3].size = 0x100000
     params.e820_table[3].type = E820_TYPE_RESERVED
     params.e820_table[4].addr = header.pref_address
-    params.e820_table[4].size = end - header.pref_address
+    params.e820_table[4].size = kernel_size
     params.e820_table[4].type = E820_TYPE_RAM
+    params.e820_table[5].addr = boot_stack_addr
+    params.e820_table[5].size = BOOT_STACK_SIZE
+    params.e820_table[5].type = E820_TYPE_RAM
+    params.e820_table[6].addr = pgtable_addr
+    params.e820_table[6].size = INIT_PGTABLE_SIZE
+    params.e820_table[6].type = E820_TYPE_RAM
+    params.e820_table[7].addr = init_end
+    params.e820_table[7].size = end - init_end
+    params.e820_table[7].type = E820_TYPE_RAM
     del params # kill reference to re-allow allocation
     # update initial registers
     state.regs.rip.value = kernel_entry
     state.regs.rsi.value = params_page
-    # load ACPI pages
-    acpi = pickle.loads(zlib.decompress(base64.b64decode(ACPI)))
-    for gpa in acpi:
-        state.memory.write(gpa, acpi[gpa])
-    return state.raw(0x200000, 0x800000, 0x801000, 0x802000, vtl)
+    return state.raw(vmsa_page, cpuid_page, secrets_page, param_page, vtl)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
To optimize the SNP VM boot, this commit
  1. modifies igvmfile.py to add IGVM_VHT_PAGE_DATA header only for code +
    data + necessary stack/pgtable in compatible 32-bit mode.
  2. modified E820_TYPE_RAM entries to define
  launch_updated memory range and leave ranges to be pvalidated as
  holes. For example, RAM entry[0:0] followed by RESERVED entry
  [0xa0000, 0x100000] tells the guest VM to pvalidate [0:0xa0000];
  3. modifies arch/x86/boot/compressed/header_64.S to pvalidate memory
    space used by kernel booting in long mode; the startup_64 needs a
    flat memory [0: startup_32+init_size] and calls
    pvalidate_for_startup_64 to pvalidates memory pages not defined in
    e820 table and to update the e820 table.

The previous SNP VM boot is slow majorly due to the expensive PSP
command LAUNCH_UPDATE per 4K page. With this patch, the 
#LAUNCH_UPDATE are reduced from ~8k to ~1k.